### PR TITLE
🔗 Update ESP32 Arduino package URL to official Espressif link

### DIFF
--- a/HID_CLIENT_README.md
+++ b/HID_CLIENT_README.md
@@ -94,7 +94,7 @@ Component config → Bluetooth →
 
 ```
 Файл → Настройки → Дополнительные ссылки для Менеджера плат:
-https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+https://espressif.github.io/arduino-esp32/package_esp32_index.json
 
 Инструменты → Плата → Менеджер плат → ESP32 → Установить
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -14,7 +14,7 @@
 ```bash
 1. Скачай Arduino IDE 2.0+
 2. Файл → Настройки → Дополнительные ссылки:
-   https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+   https://espressif.github.io/arduino-esp32/package_esp32_index.json
 3. Инструменты → Менеджер плат → ESP32 → Установить
 4. Готово!
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@
 ## Настройка программного обеспечения
 1. Установите Arduino IDE.
 2. Установите пакет плат ESP32 в Arduino IDE:
-   - Перейдите в `Файл > Настройки`, добавьте `https://raw.githubusercontent.com/espressif/arduino-esp32/master/package_esp32_index.json` в поле "Дополнительные URL менеджеров плат".
+   - Перейдите в `Файл > Настройки`, добавьте `https://espressif.github.io/arduino-esp32/package_esp32_index.json` в поле "Дополнительные URL менеджеров плат".
    - Перейдите в `Инструменты > Платы > Менеджер плат`, найдите "ESP32" и установите пакет ESP32 от Espressif.
 3. Загрузите приведенный ниже код в Arduino IDE.
 4. Выберите вашу плату ESP32 (например, `ESP32 Dev Module`) в `Инструменты > Плата`.

--- a/arduino_config.txt
+++ b/arduino_config.txt
@@ -20,7 +20,7 @@
 └─────────────────────┴─────────────────────────────────────────────────────────────┘
 
 ДОПОЛНИТЕЛЬНЫЕ URL МЕНЕДЖЕРОВ ПЛАТ:
-https://raw.githubusercontent.com/espressif/arduino-esp32/master/package_esp32_index.json
+https://espressif.github.io/arduino-esp32/package_esp32_index.json
 
 ТРЕБУЕМЫЕ БИБЛИОТЕКИ:
 ┌─────────────────────┬─────────────┬─────────────────────────────────────────────────┐


### PR DESCRIPTION
- Fixed all references from old GitHub raw URLs to new official URL
- Updated INSTALLATION.md, HID_CLIENT_README.md, arduino_config.txt, README.markdown
- Changed from: raw.githubusercontent.com/espressif/arduino-esp32/...
- Changed to: https://espressif.github.io/arduino-esp32/package_esp32_index.json

This ensures users get the latest stable ESP32 Arduino package from the official source.